### PR TITLE
Added support for RegExp in allowOrigins

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -8,10 +8,13 @@ return [
     |--------------------------------------------------------------------------
     |
     | Indicates which origins are allowed to perform requests.
+    | 'allowOriginsRegExp' is a boolean that if set to true enables RegExp
+    | support for 'allowOrigins'.
     |
     */
 
-    'allowOrigins'     => [],
+    'allowOriginsRegExp' => false,
+    'allowOrigins'       => [],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Contracts/CorsService.php
+++ b/src/Contracts/CorsService.php
@@ -56,4 +56,11 @@ interface CorsService
      */
     public function isRequestAllowed(Request $request);
 
+    /**
+     * Stores the relevant CORS headers according to configuration settings and the Request object.
+     * The fields are stored in the Request objects ParameterBag $attribute under the 'x-sentry-cors-headers' key
+     *
+     * @param Request $request
+     */
+    public function corsHeaders(Request $request);
 }

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -96,20 +96,16 @@ class CorsService implements CorsServiceContract
     public function corsHeaders(Request $request) {
         $headers = [];
 
-        //$response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
         $headers['Access-Control-Allow-Origin'] = $request->headers->get('Origin');
 
         $vary = $request->headers->has('Vary') ? $request->headers->get('Vary') . ', Origin' : 'Origin';
-        //$response->headers->set('Vary', $vary);
         $headers['Vary'] = $vary;
 
         if ($this->allowCredentials) {
-            //$response->headers->set('Access-Control-Allow-Credentials', 'true');
             $headers['Access-Control-Allow-Credentials'] =  'true';
         }
 
         if ($this->exposeHeaders) {
-            //$response->headers->set('Access-Control-Expose-Headers', implode(', ', $this->exposeHeaders));
             $headers['Access-Control-Expose-Headers'] = implode(', ', $this->exposeHeaders);
         }
 

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -156,7 +156,7 @@ class CorsService implements CorsServiceContract
                 }
                 // Build a single regexp for matching
                 if ( isset($config['allowOriginsRegExp']) && $config['allowOriginsRegExp'] ) {
-                    $this->allowOriginsRegExp = "/^(" . implode('|', $this->allowOrigins) . ")$/";
+                    $this->allowOriginsRegExp = "/^(?:" . implode('|', $this->allowOrigins) . ")$/";
                 }
             }
         }

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -90,25 +90,44 @@ class CorsService implements CorsServiceContract
         return $this->createPreflightResponse($request);
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function corsHeaders(Request $request) {
+        $headers = [];
+
+        //$response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
+        $headers['Access-Control-Allow-Origin'] = $request->headers->get('Origin');
+
+        $vary = $request->headers->has('Vary') ? $request->headers->get('Vary') . ', Origin' : 'Origin';
+        //$response->headers->set('Vary', $vary);
+        $headers['Vary'] = $vary;
+
+        if ($this->allowCredentials) {
+            //$response->headers->set('Access-Control-Allow-Credentials', 'true');
+            $headers['Access-Control-Allow-Credentials'] =  'true';
+        }
+
+        if ($this->exposeHeaders) {
+            //$response->headers->set('Access-Control-Expose-Headers', implode(', ', $this->exposeHeaders));
+            $headers['Access-Control-Expose-Headers'] = implode(', ', $this->exposeHeaders);
+        }
+
+        $request->attributes->set('x-sentry-cors-headers', $headers);
+    }
 
     /**
      * @inheritdoc
      */
     public function handleRequest(Request $request, Response $response)
     {
-        $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
-
-        $vary = $request->headers->has('Vary') ? $request->headers->get('Vary') . ', Origin' : 'Origin';
-        $response->headers->set('Vary', $vary);
-
-        if ($this->allowCredentials) {
-            $response->headers->set('Access-Control-Allow-Credentials', 'true');
+        if (empty($request->attributes->get('x-sentry-cors-headers'))) {
+            $this->corsHeaders($request);
         }
-
-        if ($this->exposeHeaders) {
-            $response->headers->set('Access-Control-Expose-Headers', implode(', ', $this->exposeHeaders));
+        $headers = $request->attributes->get('x-sentry-cors-headers');
+        foreach($headers as $header => $value) {
+            $response->headers->set($header, $value);
         }
-
         return $response;
     }
 

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -14,6 +14,8 @@ class CorsService implements CorsServiceContract
      */
     private $allowOrigins = [];
 
+    private $allowOriginsRegExp = false;
+
     /**
      * Allowed HTTP methods.
      *
@@ -151,6 +153,10 @@ class CorsService implements CorsServiceContract
             } else {
                 foreach ($config['allowOrigins'] as $origin) {
                     $this->allowOrigin($origin);
+                }
+                // Build a single regexp for matching
+                if ( isset($config['allowOriginsRegExp']) && $config['allowOriginsRegExp'] ) {
+                    $this->allowOriginsRegExp = "/^(" . implode('|', $this->allowOrigins) . ")$/";
                 }
             }
         }
@@ -295,6 +301,9 @@ class CorsService implements CorsServiceContract
      */
     protected function isOriginAllowed($origin)
     {
+        if ($this->allowOriginsRegExp) {
+            return (preg_match($this->allowOriginsRegExp, $origin) == 1);
+        }
         return $this->allowOrigins === true ?: in_array($origin, $this->allowOrigins);
     }
 

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -121,9 +121,6 @@ class CorsService implements CorsServiceContract
      */
     public function handleRequest(Request $request, Response $response)
     {
-        if (empty($request->attributes->get('x-sentry-cors-headers'))) {
-            $this->corsHeaders($request);
-        }
         $headers = $request->attributes->get('x-sentry-cors-headers');
         foreach($headers as $header => $value) {
             $response->headers->set($header, $value);

--- a/src/Middleware/CorsMiddleware.php
+++ b/src/Middleware/CorsMiddleware.php
@@ -49,6 +49,12 @@ class CorsMiddleware
 			return new Response(static::CORS_REQUEST_NOT_ALLOWED, 403);
 		}
 
+		/**
+         * we need to extract and store the CORS headers if something further down the chain fails and we won't
+         * come back. Adding the CORS headers is the last thing we do...
+         */
+		$this->service->corsHeaders($request);
+
 		return $this->service->handleRequest($request, $next($request));
 	}
 }

--- a/tests/unit/CorsRegExpServiceTest.php
+++ b/tests/unit/CorsRegExpServiceTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use Nord\Lumen\Cors\CorsService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Codeception\TestCase\Test;
+
+class CorsRegExpServiceTest extends Test
+{
+
+    use Codeception\Specify;
+
+    /**
+     * @var CorsService
+     */
+    protected $service;
+
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * @var Response
+     */
+    protected $response;
+
+    public function testIsRequestAllowed()
+    {
+        $this->service = new CorsService;
+
+        $this->request  = new Request;
+
+        $this->specify('request is not allowed', function () {
+            $this->request->headers->set('Origin', 'http://foo.com');
+
+            verify($this->service->isRequestAllowed($this->request))->false();
+        });
+
+    }
+
+    public function testIsRequestAllowedRegExp()
+    {
+        // RegExp is disabled as default, this should fail
+        $this->service = new CorsService([
+            'allowOrigins' => ["https?:\/\/.*-tv\.foo.com"],
+        ]);
+
+        $this->request  = new Request;
+
+        $this->specify('request is not allowed', function () {
+            $this->request->headers->set('Origin', 'http://t-tv.foo.com');
+            verify($this->service->isRequestAllowed($this->request))->false();
+        });
+
+        // Enable RegExp support and add rules
+        $this->service = new CorsService([
+            'allowOriginsRegExp' => true,
+            'allowOrigins' => [
+                "https?:\/\/.*-tv\.foo.com",
+                "http:\/\/.*yousee.dk",
+                "https?:\/\/localhost:(10007|8443)"
+            ]
+        ]);
+
+        $this->specify('request is allowed', function () {
+            $this->request->headers->set('Origin', 'http://t-tv.foo.com');
+            verify($this->service->isRequestAllowed($this->request))->true();
+
+            $this->request->headers->set('Origin', 'http://s-tv.foo.com');
+            verify($this->service->isRequestAllowed($this->request))->true();
+            ;
+
+            $this->request->headers->set('Origin', 'https://s-tv.foo.com');
+            verify($this->service->isRequestAllowed($this->request))->true();
+
+            $this->request->headers->set('Origin', 'http://sb8gdf87fd.yousee.dk');
+            verify($this->service->isRequestAllowed($this->request))->true();
+
+            $this->request->headers->set('Origin', 'http://www.yousee.dk');
+            verify($this->service->isRequestAllowed($this->request))->true();
+
+            $this->request->headers->set('Origin', 'http://www.yousee.dk');
+            verify($this->service->isRequestAllowed($this->request))->true();
+
+            $this->request->headers->set('Origin', 'http://localhost:10007');
+            verify($this->service->isRequestAllowed($this->request))->true();
+
+            $this->request->headers->set('Origin', 'https://localhost:8443');
+            verify($this->service->isRequestAllowed($this->request))->true();
+        });
+
+        $this->specify('request is not allowed', function () {
+            $this->request->headers->set('Origin', 'http://ttv.foo.com');
+            verify($this->service->isRequestAllowed($this->request))->false();
+
+            $this->request->headers->set('Origin', 'http://www.tdc.dk');
+            verify($this->service->isRequestAllowed($this->request))->false();
+
+            $this->request->headers->set('Origin', 'https://sb8gdf87fd.yousee.dk');
+            verify($this->service->isRequestAllowed($this->request))->false();
+
+            $this->request->headers->set('Origin', 'https://localhost:8080');
+            verify($this->service->isRequestAllowed($this->request))->false();
+        });
+
+    }
+
+}

--- a/tests/unit/CorsServiceTest.php
+++ b/tests/unit/CorsServiceTest.php
@@ -159,6 +159,7 @@ class CorsServiceTest extends \Codeception\TestCase\Test
 
         $this->specify('response origin header is set', function () {
             $this->request->headers->set('Origin', 'http://foo.com');
+            $this->service->corsHeaders($this->request);
 
             $response = $this->service->handleRequest($this->request, $this->response);
 
@@ -172,6 +173,7 @@ class CorsServiceTest extends \Codeception\TestCase\Test
         $this->specify('response vary header is set', function () {
             $this->request->headers->set('Origin', 'http://foo.com');
             $this->request->headers->set('Vary', 'Accept-Encoding');
+            $this->service->corsHeaders($this->request);
 
             $response = $this->service->handleRequest($this->request, $this->response);
 
@@ -187,6 +189,7 @@ class CorsServiceTest extends \Codeception\TestCase\Test
 
         $this->specify('response credentials header is set', function () {
             $this->request->headers->set('Origin', 'http://foo.com');
+            $this->service->corsHeaders($this->request);
 
             $response = $this->service->handleRequest($this->request, $this->response);
 
@@ -202,6 +205,7 @@ class CorsServiceTest extends \Codeception\TestCase\Test
 
         $this->specify('response expose headers header is set', function () {
             $this->request->headers->set('Origin', 'http://foo.com');
+            $this->service->corsHeaders($this->request);
 
             $response = $this->service->handleRequest($this->request, $this->response);
 


### PR DESCRIPTION
If setting 'allowOriginsRegExp' to true in the config it is possible to
specify RegExp rules in the 'allowOrign' array instead of urls.